### PR TITLE
Added reporting for skipped records

### DIFF
--- a/abstract_importer.gemspec
+++ b/abstract_importer.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "minitest-reporters-turn_reporter"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "sqlite3"
-  spec.add_development_dependency "pg"
+  spec.add_development_dependency "pg", "~> 0.18"
   spec.add_development_dependency "pry"
   spec.add_development_dependency "rr"
   spec.add_development_dependency "database_cleaner"

--- a/lib/abstract_importer/reporters/base_reporter.rb
+++ b/lib/abstract_importer/reporters/base_reporter.rb
@@ -38,6 +38,9 @@ module AbstractImporter
       def record_failed(record, hash)
       end
 
+      def record_skipped(hash)
+      end
+
       def batch_inserted(size)
       end
 

--- a/lib/abstract_importer/reporters/dot_reporter.rb
+++ b/lib/abstract_importer/reporters/dot_reporter.rb
@@ -13,6 +13,11 @@ module AbstractImporter
         super
       end
 
+      def record_skipped(hash)
+        io.print "_"
+        super
+      end
+
       def batch_inserted(size)
         io.print "." * size
         super

--- a/lib/abstract_importer/reporters/progress_reporter.rb
+++ b/lib/abstract_importer/reporters/progress_reporter.rb
@@ -30,6 +30,10 @@ module AbstractImporter
         pbar.inc
       end
 
+      def record_skipped(hash)
+        pbar.inc
+      end
+
       def batch_inserted(size)
         pbar.inc size
       end

--- a/lib/abstract_importer/strategies/default_strategy.rb
+++ b/lib/abstract_importer/strategies/default_strategy.rb
@@ -10,6 +10,7 @@ module AbstractImporter
 
         if already_imported?(hash)
           summary.already_imported += 1
+          reporter.record_skipped hash
           return
         end
 
@@ -17,6 +18,7 @@ module AbstractImporter
 
         if redundant_record?(hash)
           summary.redundant += 1
+          reporter.record_skipped hash
           return
         end
 
@@ -27,6 +29,7 @@ module AbstractImporter
         end
       rescue ::AbstractImporter::Skip
         summary.skipped += 1
+        reporter.record_skipped hash
       end
 
 

--- a/lib/abstract_importer/strategies/insert_strategy.rb
+++ b/lib/abstract_importer/strategies/insert_strategy.rb
@@ -18,6 +18,7 @@ module AbstractImporter
 
         if already_imported?(hash)
           summary.already_imported += 1
+          reporter.record_skipped hash
           return
         end
 
@@ -25,6 +26,7 @@ module AbstractImporter
 
         if redundant_record?(hash)
           summary.redundant += 1
+          reporter.record_skipped hash
           return
         end
 
@@ -32,6 +34,7 @@ module AbstractImporter
 
       rescue ::AbstractImporter::Skip
         summary.skipped += 1
+        reporter.record_skipped hash
       end
 
 

--- a/lib/abstract_importer/strategies/replace_strategy.rb
+++ b/lib/abstract_importer/strategies/replace_strategy.rb
@@ -12,6 +12,7 @@ module AbstractImporter
 
         if redundant_record?(hash)
           summary.redundant += 1
+          reporter.record_skipped hash
           return
         end
 
@@ -22,6 +23,7 @@ module AbstractImporter
         end
       rescue ::AbstractImporter::Skip
         summary.skipped += 1
+        reporter.record_skipped hash
       end
 
 


### PR DESCRIPTION
Without reporting skipped records, progress vs. total can become wildly inaccurate.