### PR TITLE
Allowed specifying a custom on_conflict for the upsert strategy

### DIFF
--- a/lib/abstract_importer/strategies/upsert_strategy.rb
+++ b/lib/abstract_importer/strategies/upsert_strategy.rb
@@ -7,7 +7,7 @@ module AbstractImporter
 
       def initialize(collection, options={})
         super
-        @insert_options.merge!(on_conflict: { column: remap_ids? ? (association_attrs.keys + [:legacy_id]) : :id, do: :update })
+        @insert_options.reverse_merge!(on_conflict: { column: remap_ids? ? (association_attrs.keys + [:legacy_id]) : :id, do: :update })
       end
 
       # We won't skip any records for already being imported


### PR DESCRIPTION
### Summary
While one might need to use the upsert strategy for its overwriting of `already_inserted?`, there might still be a need to pass a customized on_conflict options hash (e.g., when there are extra specifications to the conflict constraints), which was possible for the insert strategy but not previously for the upsert strategy.